### PR TITLE
Track cloaked elements so they can be hidden again before caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It handle Turbolinks events to properly clean up the DOM from Alpine generated c
 ## Install
 
 ### From CDN
-Just include `<script src="https://cdn.jsdelivr.net/npm/alpine-turbolinks-adapter@0.1.x/dist/alpine-turbolinks-adapter.min.js" defer></script>` along with your Alpine script in your page.
+Just include `<script src="https://cdn.jsdelivr.net/npm/alpine-turbolinks-adapter@0.1.x/dist/alpine-turbolinks-adapter.min.js" defer></script>` before your Alpine script in your page.
 
 ### From NPM
  Install the package
@@ -15,6 +15,6 @@ npm i alpine-turbolinks-adapter
 ```
 Include it in your script along with Alpine JS.
 ```javascript
-import 'alpinejs'
 import 'alpine-turbolinks-adapter'
+import 'alpinejs'
 ```

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -1,8 +1,31 @@
 import { isValidVersion } from './utils'
 
+const XCLOAK = 'x-cloak'
+const WAS_CLOAKED = 'data-alpine-was-cloaked'
+const ALPINE_GENERATED = 'data-alpine-generated-me'
+
+const LOAD_SELECTOR = '[x-cloak]'
+const BEFORE_RENDER_SELECTOR = '[data-alpine-generated-me],[x-cloak]'
+const BEFORE_CACHE_SELECTOR = '[x-for],[x-if],[data-alpine-was-cloaked]'
+
 export default class Bridge {
-  constructor () {
-    this.setAlpine(window.Alpine) // eslint-disable-line no-undef
+  init () {
+    const initAlpine = window.deferLoadingAlpine || ((callback) => callback())
+    window.deferLoadingAlpine = (callback) => {
+      this.setAlpine(window.Alpine) // eslint-disable-line no-undef
+
+      document.addEventListener('turbolinks:load', () => {
+        // Tag all cloaked elements on first page load.
+        document.body.querySelectorAll(LOAD_SELECTOR).forEach((node) => {
+          this.tagCloakedElement(node)
+        })
+        this.configureEventHandlers()
+
+        // Alpine needs to wait until after page load because it immediatly
+        // initializes components, which will remove the x-cloak attribute.
+        initAlpine(callback)
+      }, { once: true })
+    }
   }
 
   setAlpine (reference) {
@@ -12,7 +35,11 @@ export default class Bridge {
     this.alpine = reference
   }
 
-  init () {
+  tagCloakedElement (node) {
+    node.setAttribute(WAS_CLOAKED, '')
+  }
+
+  configureEventHandlers () {
     // Once Turbolinks finished is magic, we initialise Alpine on the new page
     // and resume the observer
     document.addEventListener('turbolinks:load', () => {
@@ -29,10 +56,18 @@ export default class Bridge {
     // are already copied over from the previous page so they retain their listener
     // and custom properties and we don't want to reset them.
     document.addEventListener('turbolinks:before-render', (event) => {
-      event.data.newBody.querySelectorAll('[data-alpine-generated-me]').forEach((el) => {
-        el.removeAttribute('data-alpine-generated-me')
-        if (typeof el.__x_for_key === 'undefined' && typeof el.__x_inserted_me === 'undefined') {
-          el.remove()
+      event.data.newBody.querySelectorAll(BEFORE_RENDER_SELECTOR).forEach((el) => {
+        if (el.hasAttribute(XCLOAK)) {
+          // When we get a new document body tag any cloaked elements so we can cloak
+          // them again before caching.
+          this.tagCloakedElement(el)
+        }
+
+        if (el.hasAttribute(ALPINE_GENERATED)) {
+          el.removeAttribute(ALPINE_GENERATED)
+          if (typeof el.__x_for_key === 'undefined' && typeof el.__x_inserted_me === 'undefined') {
+            el.remove()
+          }
         }
       })
     })
@@ -48,18 +83,24 @@ export default class Bridge {
     document.addEventListener('turbolinks:before-cache', () => {
       this.alpine.pauseMutationObserver = true
 
-      document.body.querySelectorAll('[x-for],[x-if]').forEach((el) => {
+      document.body.querySelectorAll(BEFORE_CACHE_SELECTOR).forEach((el) => {
+        // Cloak any elements again that were tagged when the page was loaded
+        if (el.hasAttribute(WAS_CLOAKED)) {
+          el.setAttribute(XCLOAK, '')
+          el.removeAttribute(WAS_CLOAKED)
+        }
+
         if (el.hasAttribute('x-for')) {
           let nextEl = el.nextElementSibling
           while (nextEl && typeof nextEl.__x_for_key !== 'undefined') {
             const currEl = nextEl
             nextEl = nextEl.nextElementSibling
-            currEl.setAttribute('data-alpine-generated-me', true)
+            currEl.setAttribute(ALPINE_GENERATED, true)
           }
         } else if (el.hasAttribute('x-if')) {
           const ifEl = el.nextElementSibling
           if (ifEl && typeof ifEl.__x_inserted_me !== 'undefined') {
-            ifEl.setAttribute('data-alpine-generated-me', true)
+            ifEl.setAttribute(ALPINE_GENERATED, true)
           }
         }
       })

--- a/tests/integration/cloak.spec.js
+++ b/tests/integration/cloak.spec.js
@@ -1,0 +1,21 @@
+/* global describe, it, cy */
+
+describe('x-cloak directives', () => {
+  it('should tag x-cloak items on first page load', () => {
+    cy.visit('/tests/res/cloak/index.html')
+
+    // Check element was tagged
+    cy.get('span').should('have.attr', 'data-alpine-was-cloaked')
+  })
+
+  it('should tag x-cloak items when navigating with turbolinks', () => {
+    cy.visit('/tests/res/cloak/index.html')
+
+    // Navigate to the second page
+    cy.get('a').click()
+    cy.url().should('equal', 'http://127.0.0.1:8080/tests/res/cloak/target.html')
+
+    // Check element was tagged
+    cy.get('span').should('have.attr', 'data-alpine-was-cloaked')
+  })
+})

--- a/tests/res/cloak/index.html
+++ b/tests/res/cloak/index.html
@@ -1,0 +1,16 @@
+<html>
+  <head>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
+      <script src="/dist/alpine-turbolinks-adapter.js"></script>
+      <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js"></script>
+  </head>
+
+  <body>
+    <a href="/tests/res/cloak/target.html">go to target</a>
+
+    <div x-data="{ open: false }">
+      <button id='toggler' @click="open = true">Opener</button>
+      <span x-show="open" x-cloak>Hidden</span>
+    </div>
+  </body>
+</html>

--- a/tests/res/cloak/target.html
+++ b/tests/res/cloak/target.html
@@ -1,0 +1,16 @@
+<html>
+  <head>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
+      <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+      <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js"></script>
+  </head>
+
+  <body>
+    <a href="/tests/res/cloak/index.html">go to index</a>
+
+    <div x-data="{ open: false }">
+      <button id='toggler' @click="open = true">Opener</button>
+      <span x-show="open" x-cloak>Hidden</span>
+    </div>
+  </body>
+</html>

--- a/tests/res/for-siblings/index.html
+++ b/tests/res/for-siblings/index.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
     <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>

--- a/tests/res/for-siblings/target.html
+++ b/tests/res/for-siblings/target.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
     <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>

--- a/tests/res/for/index.html
+++ b/tests/res/for/index.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
     <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>

--- a/tests/res/for/target.html
+++ b/tests/res/for/target.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
     <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>

--- a/tests/res/if/index.html
+++ b/tests/res/if/index.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
     <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>

--- a/tests/res/if/target.html
+++ b/tests/res/if/target.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
     <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>

--- a/tests/res/mutation/index.html
+++ b/tests/res/mutation/index.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
     <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>

--- a/tests/res/permanent-for/index.html
+++ b/tests/res/permanent-for/index.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
     <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>

--- a/tests/res/permanent-for/target.html
+++ b/tests/res/permanent-for/target.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
     <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>

--- a/tests/res/permanent/index.html
+++ b/tests/res/permanent/index.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
     <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>

--- a/tests/res/permanent/target.html
+++ b/tests/res/permanent/target.html
@@ -1,8 +1,8 @@
 <html>
   <head>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-      <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
       <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+      <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>


### PR DESCRIPTION
This PR is working towards fixing #9 

This PR has a few distinct changes to help solve the flashing elements issue:
1. Switched to required the adapter to be loaded before Alpine. This is so we can hook into `deferLoadingAlpine` and do some work (tagging `x-cloak` elements) before Alpine starts.
2. Tag any elements with `x-cloak` on page load or turbolinks navigation so the `x-cloak` attribute can be restored when the dom is cached.

### Outstanding issues:
1. I don't like that I'm using `turbolinks:load` event to determine that the DOM is loaded and I can tag the `x-cloak` elements. I especially don't like that Alpine is initialized at the end of that event handler. It might be fine, but it feels wrong to me.
2. The tests still aren't great because they are only testing that the elements are being tagged and not testing for the outcome. There is no real test that the tagged elements get cloaked, and then hidden, correctly because those tests were passing before any of this code was written.

### Previous outdated PR description:

I don't think this PR is ready to merge, but opening it so we can continue discussing the approach. There are a few issues with the current implementation:
1. I added a couple of tests looking for the custom attribute that gets added but ideally we would test for outcomes (element was visible etc). The problem is the current code reinitializes the components so if you show or hide an element, navigate forward and back, Alpine will reinitialize the component into the correct state before the test runs.
2. ~The test for initial page load doesn't work, even when just checking for the attribute being added. I tested against a real project and it seemed to work correctly there so might be a timing issue in the test (I'm not super familiar with cypress and js testing).~ Test for initial page load is working with the latest changes.
3. The script needs to be included with `defer`, it will most likely error if it isn't included with `defer`.

I attempted to use `deferLoadingAlpine` as we discussed so it would work without the script being deferred, the problem is if Alpine is required first it will run the check the defer loading function before the bridge script executes https://github.com/alpinejs/alpine/blob/master/src/index.js#L126, so by the time the bridge script runs Alpine is already started. For this to work `alpine-turbolins-adapter` would need to be loaded before Alpine itself. I wasn't sure if this was the correct direction to take or if there was another option I might be missing.